### PR TITLE
Update to .NET 11 Preview 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: build
 
 on:
   push:
-    branches: [main]
+    branches: [main, dotnet-vnext]
     paths-ignore:
       - "**/*.gitattributes"
       - "**/*.gitignore"
       - "**/*.md"
   pull_request:
-    branches: [main]
+    branches: [main, dotnet-vnext]
   workflow_dispatch:
 
 env:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,12 +10,12 @@
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="Dunet" Version="1.16.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
-    <PackageVersion Include="HwoodiwissApplication" Version="1.0.4" />
+    <PackageVersion Include="HwoodiwissApplication" Version="1.0.0-pr89.185" /> <!-- Keep on the -pr89 branch for the duration of the preview period -->
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.2.26159.112" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.2.26159.112" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="11.0.0-preview.2.26159.112" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.2.26159.112" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.4.26230.115" />
     <PackageVersion Include="Microsoft.AspNetCore.Testing" Version="10.4.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.2.26159.112",
+    "version": "11.0.100-preview.4.26230.115",
     "allowPrerelease": false,
     "paths": ["./build/.dotnetcli", "$host$"],
     "errorMessage": "The required .NET SDK version is not installed, run ./build/build.ps1 to install it locally to the project."


### PR DESCRIPTION
Updates build SDK and core dependencies to .NET 11 Preview 4

Moves to pre-release branch of HwoodiwissApplication, -pr89 branch tracks dotnet-vnext on that repo

